### PR TITLE
1.5 Feature: Lock and reset layouts for member groups

### DIFF
--- a/themes/third_party/dashee/css/cp.css
+++ b/themes/third_party/dashee/css/cp.css
@@ -9,7 +9,7 @@
 
 
 /* Module CSS */
-#dashListing { height:300px; overflow:auto; margin: 0 3.3% 25px; }
+#dashListing { height:320px; overflow:auto; margin: 0 3.3% 25px; }
 
 #dashContainer .column { 
     float: left;

--- a/third_party/dashee/ext.dashee.php
+++ b/third_party/dashee/ext.dashee.php
@@ -46,7 +46,7 @@ class Dashee_ext {
 		$this->settings = $settings;
 		
         $this->_base_qs     = 'C=addons_modules'.AMP.'M=show_module_cp'.AMP.'module=dashee';
-        $this->_base_url    = BASE .AMP .$this->_base_qs;
+        $this->_base_url    = (defined('BASE') ? BASE : SELF).AMP.$this->_base_qs;
 	}
 	
 function settings()
@@ -163,6 +163,7 @@ function settings()
 	{
 		if (REQ == 'CP' && $this->_EE->input->get('C') == 'homepage')
 		{
+
 			$u = $data->userdata;
 
 			// redirect super admins?
@@ -176,16 +177,16 @@ function settings()
 
 				if(empty($dashee_id)) return;
 
-				if($u['assigned_modules'][$dashee_id] != TRUE && $u['group_id'] != 1) return;
+				if( @$u['assigned_modules'][$dashee_id] != TRUE && $u['group_id'] != 1) return;
 
 				//all ok, build the url
 				$s = 0;
-				if ($u['admin_session_type'] != 'c')
+				if ($this->_EE->config->item('admin_session_type') != 'c')
 				{
 					$s = $u['session_id'];
 				}
-				$this->_EE->functions->redirect(SELF.'?S='.$s.AMP.'D=cp'.AMP.$this->_base_qs);  
-
+				header('Location: '.SELF. str_replace('&amp;', '&', '?S=' . $s . AMP . 'D=cp' . AMP . $this->_base_qs) );
+				exit;
 			}
 		}
 	}

--- a/third_party/dashee/language/english/lang.dashee.php
+++ b/third_party/dashee/language/english/lang.dashee.php
@@ -29,6 +29,7 @@ $lang = array(
 	'thOptions'		=> 'Options',
 	'thMemberGroup' => 'Member Group',
 	'thLayout'		=> 'Layout',
+	'thLocked'		=> 'Lock layout',
 	
 	'prefNumColumns'=> 'Number of columns?',
 	'prefReset'		=> 'Reset all user dashboards to the new defaults set above.',
@@ -83,6 +84,9 @@ $lang = array(
 	
 	'wgt_blank_name' => 'Blank Widget',
 	'wgt_blank_description' => 'Blank text widget, can be configured with whatever content you wish.',
+
+	'wgt_text_name' => 'Static text widget',
+	'wgt_text_description' => 'A basic widget with static text.',
 	
 );
 

--- a/third_party/dashee/language/english/lang.dashee.php
+++ b/third_party/dashee/language/english/lang.dashee.php
@@ -32,6 +32,9 @@ $lang = array(
 	
 	'prefNumColumns'=> 'Number of columns?',
 	'prefReset'		=> 'Reset all user dashboards to the new defaults set above.',
+
+	// extension settings
+	'redirect_admins'	=> 'Redirect Super-Admins to DashEE from CP Homepage?',
 	
 	'lblLayoutName' => 'Layout name',
 	'lblLayoutDesc' => 'Description',

--- a/third_party/dashee/mcp.dashee.php
+++ b/third_party/dashee/mcp.dashee.php
@@ -65,7 +65,7 @@ class Dashee_mcp {
         // get current members dash configuration for use throughout module
         $this->_get_member_settings($this->_member_id);
 	}
-	
+
 	// ----------------------------------------------------------------
 
 	/**
@@ -76,7 +76,8 @@ class Dashee_mcp {
 	public function index()
 	{
         $this->_EE->cp->add_to_head('<link rel="stylesheet" type="text/css" href="'.$this->_css_url.'" />');
-        $this->_EE->cp->add_to_head('<script type="text/javascript" src="'.$this->_js_url.'"></script>');
+        // is the member_group layout locked?
+        if($this->_settings['locked'] == FALSE) $this->_EE->cp->add_to_head('<script type="text/javascript" src="'.$this->_js_url.'"></script>');
 	
 		$this->_EE->cp->set_variable('cp_page_title', lang('dashee_term'));
 		
@@ -91,7 +92,8 @@ class Dashee_mcp {
 		
 		$button_data['btn_widgets']  = '#widgets'; 
 		$button_data['btn_settings'] = $this->_base_url.AMP.'method=settings';
-		$this->_EE->cp->set_right_nav($button_data);
+        // is the member_group layout locked?
+        if($this->_settings['locked'] == FALSE) $this->_EE->cp->set_right_nav($button_data);
 		
 		// override default breadcrumb display to make module look like default CP homepage
 		$this->_EE->javascript->output("
@@ -594,11 +596,17 @@ class Dashee_mcp {
 	 */
 	public function update_group_defaults()
 	{
+		if($this->_super_admin == FALSE)
+		{
+			show_error(lang('unauthorized_access'));
+		}
+
 		$group_layouts = $this->_EE->input->post('group_layouts');
+		$group_locked = $this->_EE->input->post('group_locked');
 		
 		if($group_layouts != '' AND is_array($group_layouts))
 		{
-			$this->_model->update_group_layouts($group_layouts);
+			$this->_model->update_group_layouts($group_layouts, $group_locked);
 		
 			/*if($this->_EE->input->post('reset') == 'yes')
 			{
@@ -613,6 +621,35 @@ class Dashee_mcp {
 		}
 		
 		$this->_EE->functions->redirect($this->_base_url.AMP.'method=settings');
+	}
+	
+	/**
+	 * Reset layout for a member group
+	 *
+	 * @return 	void
+	 */
+	public function reset_group_defaults()
+	{
+		$group_id = $this->_EE->input->get('group_id');
+
+		if($this->_super_admin == false)
+		{
+            show_error(lang('unauthorized_access'));
+		}
+		
+		if($group_id != '' AND is_numeric($group_id))
+		{
+			$this->_model->reset_member_layouts($group_id);
+			
+			$this->_EE->session->set_flashdata('dashee_msg', 'Config has been reset for member group '.$group_id);
+		}
+		else
+		{
+			$this->_EE->session->set_flashdata('dashee_msg', 'No group_id to reset');
+		}
+		
+		$this->_EE->functions->redirect($this->_base_url.AMP.'method=settings');
+
 	}
 	
 	/**

--- a/third_party/dashee/models/dashee_model.php
+++ b/third_party/dashee/models/dashee_model.php
@@ -40,7 +40,7 @@ class Dashee_model extends CI_Model {
         $this->_EE =& get_instance();
         
         $this->_package_name    = 'dashEE';
-        $this->_package_version = '1.4';
+        $this->_package_version = '1.5';
     }
     
     /**
@@ -253,7 +253,13 @@ class Dashee_model extends CI_Model {
 				'type' 			=> 'INT',
 				'constraint' 	=> 10,
 				'unsigned'		=> TRUE,
-				)
+				),
+			'locked' => array(
+				'type' 			=> 'INT',
+				'constraint' 	=> 1,
+				'unsigned'		=> TRUE,
+				'null'			=> FALSE,
+				),
 			);
 			
 		$this->_EE->dbforge->add_field($fields);
@@ -313,6 +319,11 @@ class Dashee_model extends CI_Model {
             $this->_update_package_to_version_14();
         }
 
+        if(version_compare($installed_version, '1.5', '<'))
+        {
+            $this->_update_package_to_version_15();
+        }
+
         // Forcibly update the module version number?
         if($force === TRUE)
         {
@@ -349,6 +360,23 @@ class Dashee_model extends CI_Model {
     	// add DB tables for storing layouts and assigning them to member groups
     	$this->install_module_layouts_table();
 		$this->install_module_layouts_groups_table();		
+    }
+
+    /**
+     * Add collumn 'locked' tot dashee_member_groups_layouts
+     *
+     * @access  private
+     * @return  void
+     */
+    private function _update_package_to_version_15()
+    {
+		$this->_EE->load->dbforge();
+
+		$fields = array(
+		  'locked' => array('type' => 'int', 'constraint' => '1', 'unsigned' => TRUE, 'null' => FALSE)
+		);
+		
+		$this->_EE->dbforge->add_column('dashee_member_groups_layouts', $fields);
     }
         
     /**
@@ -411,25 +439,38 @@ class Dashee_model extends CI_Model {
 				$layout_id = $qry->row()->layout_id;
 				$layout = $this->get_layout($layout_id);
 				$config = $layout->config;
+				$locked_group = ($qry->row()->locked == 1) ? TRUE : FALSE;
 			}
 			else
 			{			
 				$qry = $this->_EE->db->get_where('dashee_layouts', array('is_default' => TRUE))->row();
 				$config = $qry->config;
+				$locked_group = FALSE;
 			}
 		
 			$params = array(
 				'member_id' => $member_id,
 				'config' 	=> $config
 				);
-				
-			$this->_EE->db->insert('dashee_members', $params);
 			
-			return json_decode($params['config'], TRUE);
+			$this->_EE->db->insert('dashee_members', $params);
+
+			$config = json_decode($params['config'], TRUE);
+			$config['locked'] = $locked_group;
+
+			return $config;
 		}
 		else
 		{
-			return json_decode($result->row()->config, TRUE);
+			// config fetched from DB
+			$config = json_decode($result->row()->config, TRUE);
+
+			// check if the member group has a locked layout
+			$qry = $this->_EE->db->get_where('dashee_member_groups_layouts', array('locked' => 1,'member_group_id' => $this->_EE->session->userdata('group_id')));
+
+			$config['locked'] = ($qry->num_rows() == 1) ? TRUE : FALSE;
+
+			return $config;
 		}
 	}
 	
@@ -495,7 +536,10 @@ class Dashee_model extends CI_Model {
 		{
 			foreach($qry->result() as $row)
 			{
-				$groups[$row->member_group_id] = $row->layout_id;
+				$groups[$row->member_group_id] = array(
+					'layout_id' => $row->layout_id,
+					'locked' => (boolean) $row->locked,
+				);
 			}
 		}
 		
@@ -554,13 +598,14 @@ class Dashee_model extends CI_Model {
      * @param 	array		$group_layouts		Assoc. array of group_id with assigned layout_id.
 	 * @return 	void
 	 */
-	public function update_group_layouts($group_layouts)
+	public function update_group_layouts($group_layouts, $group_locked)
 	{
 		$this->_EE->db->truncate('dashee_member_groups_layouts');
 		
 		foreach($group_layouts as $group_id => $layout_id)
 		{
-			$this->_EE->db->insert('dashee_member_groups_layouts', array('member_group_id' => $group_id, 'layout_id' => $layout_id));
+			$locked = (isset($group_locked[$group_id])&& $group_locked[$group_id]=='locked') ? 1 : 0;
+			$this->_EE->db->insert('dashee_member_groups_layouts', array('member_group_id' => $group_id, 'layout_id' => $layout_id, 'locked'=>$locked));
 		}
 	}
 	
@@ -571,12 +616,15 @@ class Dashee_model extends CI_Model {
      * @param 	array		$group_layouts		Assoc. array of group_id with assigned layout_id.
 	 * @return 	void
 	 */
-	public function reset_member_layouts()
+	public function reset_member_layouts($group_id = FALSE)
 	{
-		$member_qry = $this->_EE->db->select('dashee_members.*, members.group_id')
+		$this->_EE->db->select('dashee_members.*, members.group_id')
 			->from('dashee_members')
-			->join('members', 'dashee_members.member_id = members.member_id')
-			->result();
+			->join('members', 'dashee_members.member_id = members.member_id');
+
+		if($group_id) $this->_EE->db->where('members.group_id', $group_id);
+
+		$member_qry = $this->_EE->db->get()->result();
 	
 		if(count($member_qry) > 0)
 		{
@@ -591,7 +639,7 @@ class Dashee_model extends CI_Model {
 			
 			foreach($member_qry as $member)
 			{
-				$this->_EE->db->update('dashee_members', array('config' => $layouts[$group_layouts[$member->group_id]]), array('id' => $member->id));
+				$this->_EE->db->update('dashee_members', array('config' => $layouts[$group_layouts[$member->group_id]['layout_id']]), array('id' => $member->id));
 			}
 		}
 	}

--- a/third_party/dashee/views/settings.php
+++ b/third_party/dashee/views/settings.php
@@ -84,15 +84,28 @@ if($is_admin):
 	$this->table->set_heading(
 	   lang('thMemberGroup'),
 	   lang('thDescription'),
+	   lang('thLocked'),
 	   lang('thLayout')
 	   );
 	
 	foreach($member_groups as $group)
 	{
+		if(array_key_exists($group->id, $group_layouts))
+		{
+			$layout_id = $group_layouts[$group->id]['layout_id'];
+			$locked = $group_layouts[$group->id]['locked'];
+		}
+		else
+		{
+			$layout_id = $default_id;
+			$locked = FALSE;
+		}
+
 		$this->table->add_row(
-			$group->title,
+			$group->title.' '.anchor($base_url.AMP.'method=reset_group_defaults'.AMP.'group_id='.$group->id, 'reset'),
 			$group->description ? $group->description : '--',
-			form_dropdown('group_layouts['.$group->id.']', $opts_layouts, array_key_exists($group->id, $group_layouts) ? $group_layouts[$group->id] : $default_id)
+			form_checkbox('group_locked['.$group->id.']','locked', $locked, ($group->id == 1 ? 'disabled="disabled"' : '')),
+			form_dropdown('group_layouts['.$group->id.']', $opts_layouts, $layout_id)
 			);
 	}
 	

--- a/third_party/dashee/widgets/wgt.text.php
+++ b/third_party/dashee/widgets/wgt.text.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Text Widget
+ *
+ * Display simple text.
+ *
+ * @package		ExpressionEngine
+ * @subpackage	Addons
+ * @category	DashEE Widget
+ */
+
+class Wgt_text
+{
+	public $title;
+	public $wclass;
+	
+	/**
+	 * Constructor
+	 */
+	public function __construct()
+	{
+		$this->wclass = 'padded';
+	}
+	
+	// ----------------------------------------------------------------
+
+	/**
+	 * Index Function
+	 *
+	 * @param	object
+	 * @return 	string
+	 */
+	public function index($settings = NULL)
+	{
+		$this->title = 'Instructions';
+		return '
+
+		<p>This is a basic, static text widget</p>
+		<p>Only contains static text</p>
+
+		';
+	}
+
+}
+/* End of file wgt.text.php */
+/* Location: /system/expressionengine/third_party/dashee/widgets/wgt.text.php */


### PR DESCRIPTION
DashEE is very flexible, but sometimes can be to flexible.
For instance, during a support-call from an editor, 
you can't be sure that the instructions-widget is still visible.

Changes and options:
- **Allow certain member_groups to be locked into a layout**
  Removes all options like dragging and buttons for users from that group.
- **Reset group_defaults**
  Restores a layout for all users in a member_group.
  Makes use of the already defined reset_member_layouts method.
- **Static text widget**
  Easy widget with static text

PS:EDIT: this is in a feature branch
