### PR TITLE
updated Dashee_model to use the URL_THIRD_THEMES constant

### DIFF
--- a/third_party/dashee/models/dashee_model.php
+++ b/third_party/dashee/models/dashee_model.php
@@ -531,10 +531,7 @@ class Dashee_model extends CI_Model
      */
     public function get_package_theme_url()
     {
-        $theme_url = $this->_EE->config->item('theme_folder_url');
-        $theme_url .= substr($theme_url, -1) == '/' ? 'third_party/' : '/third_party/';
-
-        return $theme_url.strtolower($this->get_package_name()).'/';
+        return URL_THIRD_THEMES.strtolower($this->get_package_name()).'/';
     }
     
     /**


### PR DESCRIPTION
Using the URL_THIRD_THEMES constant allows us to use the config override to move the third party folder from its default location. Thanks!
